### PR TITLE
Fix token validation command

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -60,7 +60,7 @@ git config --global credential.helper store
 git config --global init.defaultBranch main
 
 # Validate the token by hitting the GitHub API
-curl -H "Authorization: token ${GH_PAT}" https://api.github.com/user >/dev/null 2>&1 || {
+curl -f -H "Authorization: token ${GH_PAT}" https://api.github.com/user >/dev/null 2>&1 || {
   echo "GitHub token validation failed" >&2
   exit 1
 }


### PR DESCRIPTION
## Summary
- ensure curl fails when GitHub PAT is invalid

## Testing
- `bash -n bootstrap.sh`

------
https://chatgpt.com/codex/tasks/task_b_685c4409b20c8321bfa7d73d6ccc0aa8